### PR TITLE
Adapt to gnome shell 3.34

### DIFF
--- a/app_menu.js
+++ b/app_menu.js
@@ -190,11 +190,11 @@ var AppMenu = new Lang.Class({
                     }
                 });
 
-                let [px, py] = Main.panel.actor.get_transformed_position();
+                let [px, py] = Main.panel.get_transformed_position();
                 let [bx, by] = label.get_transformed_position();
                 let [w, h] = label.get_transformed_size();
 
-                let y = py + Main.panel.actor.get_height() + 3;
+                let y = py + Main.panel.get_height() + 3;
                 let x = bx - Math.round((this._tooltip.get_width() - w)/2);
                 this._tooltip.opacity = 0;
                 this._tooltip.set_position(x, y);
@@ -243,7 +243,7 @@ var AppMenu = new Lang.Class({
         this._focusCallbackID = global.display.connect('notify::focus-window', Lang.bind(this, this._onFocusChange));
         this._onFocusChange();
 
-        this._tooltipCallbackID = this._appMenu.actor.connect('notify::hover',
+        this._tooltipCallbackID = this._appMenu.connect('notify::hover',
             Lang.bind(this, this._onAppMenuHover));
         this._globalCallBackID = display.connect('restacked',
             Lang.bind(this, this._updateAppMenu));
@@ -289,7 +289,7 @@ var AppMenu = new Lang.Class({
         }
 
         if (this._tooltipCallbackID) {
-            this._appMenu.actor.disconnect(this._tooltipCallbackID);
+            this._appMenu.disconnect(this._tooltipCallbackID);
             this._tooltipCallbackID = 0;
         }
 

--- a/app_menu.js
+++ b/app_menu.js
@@ -70,7 +70,8 @@ var AppMenu = new Lang.Class({
         // Not the topmost maximized window.
         if (win !== Utils.getWindow()) {
             let app = Shell.WindowTracker.get_default().get_window_app(win);
-            title = app.get_name();
+            if (app)
+                title = app.get_name();
         }
 
         // Not on the primary monitor

--- a/app_menu.js
+++ b/app_menu.js
@@ -15,10 +15,9 @@ let SHOW_DELAY = 350;
 let SHOW_DURATION = 0.15;
 let HIDE_DURATION = 0.1;
 
-var AppMenu = new Lang.Class({
-    Name: 'NoTitleBar.AppMenu',
+var AppMenu = class {
 
-    _init: function(settings) {
+    constructor(settings) {
         this._wmCallbackIDs = [];
         this._focusCallbackID = 0;
         this._tooltipCallbackID = 0;
@@ -54,12 +53,12 @@ var AppMenu = new Lang.Class({
             this._enable();
         else
             this._disable();
-    },
+    }
 
     /**
      * AppMenu synchronization
      */
-    _updateAppMenu: function() {
+    _updateAppMenu() {
         let win = global.display.focus_window;
         if (!win) {
             return false;
@@ -83,9 +82,9 @@ var AppMenu = new Lang.Class({
         this._tooltip.text = title;
 
         return false;
-    },
+    }
 
-    _updateAppMenuWidth: function() {
+    _updateAppMenuWidth() {
         this._restoreAppMenuWidth();
 
         let width = this._settings.get_int('app-menu-width');
@@ -93,16 +92,16 @@ var AppMenu = new Lang.Class({
             this._appMenu._label.set_style('max-width: ' + width + 'px');
 
         this._updateAppMenu();
-    },
+    }
 
-    _restoreAppMenuWidth: function() {
+    _restoreAppMenuWidth() {
         this._appMenu._label.set_style('max-width');
-    },
+    }
 
     /**
      * Track the focused window's title
      */
-    _changeActiveWindow: function (win) {
+    _changeActiveWindow(win) {
         if (win === this._activeWindow) {
             return;
         }
@@ -117,12 +116,12 @@ var AppMenu = new Lang.Class({
             this._awCallbackID = win.connect('notify::title', Lang.bind(this, this._updateAppMenu));
             this._updateAppMenu();
         }
-    },
+    }
 
     /**
      * Focus change
      */
-    _onFocusChange: function() {
+    _onFocusChange() {
         let input_mode_check = (global.stage_input_mode === undefined)
             ? true
             : global.stage_input_mode == Shell.StageInputMode.FOCUSED;
@@ -135,20 +134,20 @@ var AppMenu = new Lang.Class({
 
         this._changeActiveWindow(global.display.focus_window);
         return false;
-    },
+    }
 
     /**
      * tooltip
      */
 
-    _resetMenuCallback: function() {
+    _resetMenuCallback() {
         if (this._menuCallbackID) {
             this._appMenu.menu.disconnect(this._menuCallbackID);
             this._menuCallbackID = 0;
         }
-    },
+    }
 
-    _onAppMenuHover: function(actor) {
+    _onAppMenuHover(actor) {
         let hover = actor.get_hover();
         if (this._showTooltip === hover) {
             return false;
@@ -230,9 +229,9 @@ var AppMenu = new Lang.Class({
         }
 
         return false;
-    },
+    }
 
-    _enable: function() {
+    _enable() {
         this._tooltip = new St.Label({
             style_class: 'tooltip dash-label',
             text: '',
@@ -265,9 +264,9 @@ var AppMenu = new Lang.Class({
         this._updateAppMenuWidth();
 
         this._isEnabled = true;
-    },
+    }
 
-    _disable: function() {
+    _disable() {
         this._wmCallbackIDs.forEach(function(id) {
             global.window_manager.disconnect(id);
         });
@@ -318,9 +317,9 @@ var AppMenu = new Lang.Class({
         this._restoreAppMenuWidth();
 
         this._isEnabled = false;
-    },
+    }
 
-    destroy: function() {
+    destroy() {
          if (this._isEnabled)
              this._disable();
 
@@ -328,5 +327,5 @@ var AppMenu = new Lang.Class({
              this._settings.disconnect(this._settingsId);
              this._settingsId = null;
          }
-    },
-});
+    }
+}

--- a/buttons.js
+++ b/buttons.js
@@ -177,13 +177,13 @@ var Buttons = new Lang.Class({
             if (boxes[1].get_children().length) {
                 switch (this._settings.get_enum('button-position')) {
                     case Position.BEFORE_NAME: {
-                        let activitiesBox = Main.panel.statusArea.activities.actor.get_parent()
+                        let activitiesBox = Main.panel.statusArea.activities.get_parent()
                         let leftBox = activitiesBox.get_parent();
                         leftBox.insert_child_above(this._container, activitiesBox);
                         break;
                     }
                     case Position.AFTER_NAME: {
-                        let appMenuBox = Main.panel.statusArea.appMenu.actor.get_parent()
+                        let appMenuBox = Main.panel.statusArea.appMenu.get_parent()
                         let leftBox = appMenuBox.get_parent();
                         leftBox.insert_child_above(this._container, appMenuBox);
                         break;
@@ -422,7 +422,7 @@ var Buttons = new Lang.Class({
             return Clutter.EVENT_STOP;
         };
 
-        Main.panel.actor.connect('button-press-event', Lang.bind(Main.panel, Main.panel._onButtonPress));
+        Main.panel.connect('button-press-event', Lang.bind(Main.panel, Main.panel._onButtonPress));
     },
     _disableDragOnPanel: function() {
         if (!this._originalFunction) {
@@ -430,7 +430,7 @@ var Buttons = new Lang.Class({
         }
 
         Main.panel._onButtonPress = this._originalFunction;
-        Main.panel.actor.connect('button-press-event', Lang.bind(Main.panel, Main.panel._onButtonPress));
+        Main.panel.connect('button-press-event', Lang.bind(Main.panel, Main.panel._onButtonPress));
     },
 
     _enable: function() {

--- a/buttons.js
+++ b/buttons.js
@@ -47,10 +47,9 @@ const DCONF_META_PATH = 'org.gnome.desktop.wm.preferences';
 
 let actors = [], boxes = [];
 
-var Buttons = new Lang.Class({
-    Name: 'NoTitleBar.Buttons',
+var Buttons = class {
 
-    _init: function(settings) {
+    constructor(settings) {
         this._extensionPath = Me.dir.get_path();
 
         this._wmCallbackIDs = [];
@@ -88,9 +87,9 @@ var Buttons = new Lang.Class({
             this._enable();
         else
             this._disable();
-    },
+    }
 
-    _createButtons: function() {
+    _createButtons() {
         // Ensure we do not create buttons twice.
         this._destroyButtons();
 
@@ -203,9 +202,9 @@ var Buttons = new Lang.Class({
             this._updateVisibility();
             return false;
         }));
-    },
+    }
 
-    _destroyButtons: function() {
+    _destroyButtons() {
         if (actors) {
             actors.forEach(function(actor, i) {
                 actor.destroy();
@@ -219,9 +218,9 @@ var Buttons = new Lang.Class({
             this._disableButtonAutohide();
             this._container.destroy();
         }
-    },
+    }
 
-    _enableButtonAutohide: function() {
+    _enableButtonAutohide() {
         this._disableButtonAutohide();
 
         if (this._container) {
@@ -230,9 +229,9 @@ var Buttons = new Lang.Class({
 
         this._containerEnterId = this._container.connect('enter-event', b_shown);
         this._containerLeaveId = this._container.connect('leave-event', b_hidden);
-    },
+    }
 
-    _disableButtonAutohide: function() {
+    _disableButtonAutohide() {
         if (this._container) {
             this._container.opacity = 255;
         }
@@ -245,12 +244,12 @@ var Buttons = new Lang.Class({
             this._container.disconnect(this._containerLeaveId);
             this._containerLeaveId = 0;
         }
-    },
+    }
 
     /**
      * Buttons actions
      */
-    _leftclick: function(callback) {
+    _leftclick(callback) {
         return function(actor, event) {
             if (event.get_button() !== 1) {
                 return null;
@@ -258,18 +257,18 @@ var Buttons = new Lang.Class({
 
             return callback(actor, event);
         }
-    },
+    }
 
-    _minimize: function() {
+    _minimize() {
         let win = Utils.getWindow();
         if (!win || win.minimized) {
             return;
         }
 
         win.minimize();
-    },
+    }
 
-    _maximize: function() {
+    _maximize() {
         let win = Utils.getWindow();
         if (!win) {
             return;
@@ -283,21 +282,21 @@ var Buttons = new Lang.Class({
         }
 
         win.activate(global.get_current_time());
-    },
+    }
 
-    _close: function() {
+    _close() {
         let win = Utils.getWindow();
         if (!win) {
             return;
         }
 
         win.delete(global.get_current_time());
-    },
+    }
 
     /**
      * Theming
      */
-    _loadTheme: function() {
+    _loadTheme() {
         let theme;
         if (this._settings.get_boolean('automatic-theme')) {
             theme = Gtk.Settings.get_default().gtk_theme_name;
@@ -327,20 +326,20 @@ var Buttons = new Lang.Class({
         });
 
         this._activeCSS = cssPath;
-    },
+    }
 
-    _unloadTheme: function() {
+    _unloadTheme() {
         if (this._activeCSS) {
             let cssFile = Gio.file_new_for_path(this._activeCSS);
             St.ThemeContext.get_for_stage(global.stage).get_theme().unload_stylesheet(cssFile);
             this._activeCSS = false;
         }
-    },
+    }
 
     /**
      * callbacks
      */
-    _updateVisibility: function() {
+    _updateVisibility() {
         // If we have a window to control, then we show the buttons.
         let visible = !Main.overview.visible;
         if (visible) {
@@ -373,8 +372,9 @@ var Buttons = new Lang.Class({
         });
 
         return false;
-    },
-    _enableDragOnPanel: function() {
+    }
+
+    _enableDragOnPanel() {
         let settings = this._settings;
 
         this._originalFunction = Main.panel._onButtonPress;
@@ -423,17 +423,18 @@ var Buttons = new Lang.Class({
         };
 
         Main.panel.connect('button-press-event', Lang.bind(Main.panel, Main.panel._onButtonPress));
-    },
-    _disableDragOnPanel: function() {
+    }
+
+    _disableDragOnPanel() {
         if (!this._originalFunction) {
             return;
         }
 
         Main.panel._onButtonPress = this._originalFunction;
         Main.panel.connect('button-press-event', Lang.bind(Main.panel, Main.panel._onButtonPress));
-    },
+    }
 
-    _enable: function() {
+    _enable() {
         this._loadTheme();
         this._createButtons();
 
@@ -455,9 +456,9 @@ var Buttons = new Lang.Class({
         this._enableDragOnPanel();
 
         this._isEnabled = true;
-    },
+    }
 
-    _disable: function() {
+    _disable() {
         this._wmCallbackIDs.forEach(function(id) {
             global.window_manager.disconnect(id);
         });
@@ -485,9 +486,9 @@ var Buttons = new Lang.Class({
         this._disableDragOnPanel();
 
         this._isEnabled = false;
-    },
+    }
 
-    destroy: function() {
+    destroy() {
         if (this._isEnabled)
             this._disable();
 
@@ -506,4 +507,4 @@ var Buttons = new Lang.Class({
             this._snappedId = 0;
         }
     }
-});
+}

--- a/decoration.js
+++ b/decoration.js
@@ -33,10 +33,9 @@ const WindowState = {
 let appSys = Shell.AppSystem.get_default();
 let workspaces = [];
 
-var Decoration = new Lang.Class({
-    Name: 'NoTitleBar.Decoration',
+var Decoration = class {
 
-    _init: function(settings) {
+    constructor(settings) {
         this._changeWorkspaceID = 0;
         this._windowEnteredID = 0;
         this._settings = settings;
@@ -94,9 +93,9 @@ var Decoration = new Lang.Class({
                 this._enable();
             })
         );
-    },
+    }
 
-    _enable: function() {
+    _enable() {
         // Connect events
         this._changeWorkspaceID = ws_manager.connect('notify::n-workspaces', Lang.bind(this, this._onChangeNWorkspaces));
         this._windowEnteredID   = display.connect('window-entered-monitor', Lang.bind(this, this._windowEnteredMonitor));
@@ -126,9 +125,9 @@ var Decoration = new Lang.Class({
         }));
 
         this._isEnabled = true;
-    },
+    }
 
-    _disable: function() {
+    _disable() {
         if (this._changeWorkspaceID) {
             ws_manager.disconnect(this._changeWorkspaceID);
             this._changeWorkspaceID = 0;
@@ -164,15 +163,15 @@ var Decoration = new Lang.Class({
         this._removeUserStyles();
 
         this._isEnabled = false;
-    },
+    }
 
-    destroy: function() {
+    destroy() {
         this._disable();
         Meta.MonitorManager.get().disconnect(this._changeMonitorsID);
         this._settings.disconnect(this._onlyMainMonitorID);
         this._settings.disconnect(this._ignoreListID);
         this._settings.disconnect(this._ignoreListTypeID);
-    },
+    }
 
     /**
      * Guesses the X ID of a window.
@@ -193,7 +192,7 @@ var Decoration = new Lang.Class({
      * @param {Meta.Window} win - the window to guess the XID of. You wil get better
      * success if the window's actor (`win.get_compositor_private()`) exists.
      */
-    _guessWindowXID: function(win) {
+    _guessWindowXID(win) {
         // We cache the result so we don't need to redetect.
         if (win._noTitleBarWindowID) {
             return win._noTitleBarWindowID;
@@ -274,7 +273,7 @@ var Decoration = new Lang.Class({
 
         // debugging for when people find bugs..
         return null;
-    },
+    }
 
     _toggleTitlebar() {
         let win = global.display.focus_window;
@@ -286,7 +285,7 @@ var Decoration = new Lang.Class({
             this._setHideTitlebar(win, true);
         else
             this._setHideTitlebar(win, false);
-    },
+    }
 
     /**
      * Get the value of _GTK_HIDE_TITLEBAR_WHEN_MAXIMIZED before
@@ -294,7 +293,7 @@ var Decoration = new Lang.Class({
      *
      * @param {Meta.Window} win - the window to check the property
      */
-    _getOriginalState: function (win) {
+    _getOriginalState (win) {
         if (win._noTitleBarOriginalState !== undefined) {
             return win._noTitleBarOriginalState;
         }
@@ -337,7 +336,7 @@ var Decoration = new Lang.Class({
         // title bar should be hidden when maximized. If we can't find this atom, the
         // window uses the default behavior
         return win._noTitleBarOriginalState = WindowState.DEFAULT;
-    },
+    }
 
     /**
      * Tells the window manager to hide the titlebar on maximised windows.
@@ -354,7 +353,7 @@ var Decoration = new Lang.Class({
      * @param {Meta.Window} win - window to set the HIDE_TITLEBAR_WHEN_MAXIMIZED property of.
      * @param {boolean} hide - whether to hide the titlebar or not.
      */
-    _setHideTitlebar: function(win, hide) {
+    _setHideTitlebar(win, hide) {
         // Check if the window is a black/white-list
         if (Utils.isWindowIgnored(this._settings, win) && hide) {
             return;
@@ -371,9 +370,9 @@ var Decoration = new Lang.Class({
         if (winXID == null)
             return;
         this._toggleDecorations(win, hide);
-    },
+    }
 
-    _updateWindowAsync: function (win, cmd) {
+    _updateWindowAsync (win, cmd) {
         // Run xprop
         let [success, pid] = GLib.spawn_async(
             null,
@@ -398,8 +397,7 @@ var Decoration = new Lang.Class({
                 win.maximize(MAXIMIZED);
             }
         }));
-
-    },
+    }
 
     _getHintValue(win, hint) {
         let winId = this._guessWindowXID(win);
@@ -415,14 +413,14 @@ var Decoration = new Lang.Class({
         });
 
         return string;
-    },
+    }
 
     _setHintValue(win, hint, value) {
         let winId = this._guessWindowXID(win);
         if (!winId) return;
 
         Util.spawn(['xprop', '-id', winId, '-f', hint, '32c', '-set', hint, value]);
-    },
+    }
 
     _getMotifHints(win) {
         if (!win._NoTitleBarOriginalState) {
@@ -437,7 +435,7 @@ var Decoration = new Lang.Class({
         }
 
         return win._NoTitleBarOriginalState;
-    },
+    }
 
     _handleWindow(win) {
         let handleWin = false;
@@ -451,9 +449,9 @@ var Decoration = new Lang.Class({
         }
 
         return handleWin;
-    },
+    }
 
-    _toggleDecorations: function (win, hide) {
+    _toggleDecorations (win, hide) {
         let winId = this._guessWindowXID(win);
 
         if (!this._handleWindow(win))
@@ -467,16 +465,16 @@ var Decoration = new Lang.Class({
                 cmd = this._toggleDecorationsGtk(winId, hide);
             this._updateWindowAsync(win, cmd);
         }));
-    },
+    }
 
-    _toggleDecorationsGtk: function (winId, hide) {
+    _toggleDecorationsGtk (winId, hide) {
         let prop = '_GTK_HIDE_TITLEBAR_WHEN_MAXIMIZED';
         let value = hide ? '0x1' : '0x0';
 
         return ['xprop', '-id', winId, '-f', prop, '32c', '-set', prop, value];
-    },
+    }
 
-    _toggleDecorationsMotif: function (winId, hide) {
+    _toggleDecorationsMotif (winId, hide) {
         let prop = '_MOTIF_WM_HINTS';
         let flag = '0x2, 0x0, %s, 0x0, 0x0';
         let value = hide
@@ -484,7 +482,7 @@ var Decoration = new Lang.Class({
             : flag.format('0x1');
 
         return ['xprop', '-id', winId, '-f', prop, '32c', '-set', prop, value];
-    },
+    }
 
     /**** Callbacks ****/
     /**
@@ -499,7 +497,7 @@ var Decoration = new Lang.Class({
      *
      * @see undecorate
      */
-    _onWindowAdded: function(ws, win, retry) {
+    _onWindowAdded(ws, win, retry) {
         if (win.window_type === Meta.WindowType.DESKTOP ||
             win.window_type === Meta.WindowType.MODAL_DIALOG) {
             return false;
@@ -556,7 +554,7 @@ var Decoration = new Lang.Class({
         }));
 
         return false;
-    },
+    }
 
     /**
      * Callback whenever the number of workspaces changes.
@@ -566,7 +564,7 @@ var Decoration = new Lang.Class({
      *
      * @see _onWindowAdded
      */
-    _onChangeNWorkspaces: function() {
+    _onChangeNWorkspaces() {
         this._cleanWorkspaces();
 
         let i = ws_manager.n_workspaces;
@@ -581,12 +579,12 @@ var Decoration = new Lang.Class({
         }
 
         return false;
-    },
+    }
 
     /* CSS styles, for Wayland decorations
      */
 
-    _updateUserStyles: function () {
+    _updateUserStyles () {
         let styleContent = '';
 
         if (GLib.file_test(this._userStylesPath, GLib.FileTest.EXISTS)) {
@@ -599,9 +597,9 @@ var Decoration = new Lang.Class({
         }
 
         return styleContent;
-    },
+    }
 
-    _addUserStyles: function () {
+    _addUserStyles () {
         let styleContent = this._updateUserStyles();
         let styleFilePath = Me.path + '/stylesheet.css';
         let styleImport = "@import url('" + styleFilePath + "');\n";
@@ -610,18 +608,18 @@ var Decoration = new Lang.Class({
         styleImport += "@import url('" + styleFilePath + "');\n";
 
         GLib.file_set_contents(this._userStylesPath, styleImport + styleContent);
-    },
+    }
 
-    _removeUserStyles: function () {
+    _removeUserStyles () {
         let styleContent = this._updateUserStyles();
         GLib.file_set_contents(this._userStylesPath, styleContent);
-    },
+    }
 
 
     /**
      * Utilities
      */
-    _cleanWorkspaces: function() {
+    _cleanWorkspaces() {
         // disconnect window-added from workspaces
         workspaces.forEach(function(ws) {
             ws.disconnect(ws._noTitleBarWindowAddedId);
@@ -629,20 +627,20 @@ var Decoration = new Lang.Class({
         });
 
         workspaces = [];
-    },
+    }
 
-    _forEachWindow: function(callback) {
+    _forEachWindow(callback) {
         global.get_window_actors()
             .map(function (w) { return w.meta_window; })
             .filter(function(w) { return w.window_type !== Meta.WindowType.DESKTOP; })
             .forEach(callback);
-    },
+    }
 
-    _windowEnteredMonitor: function(metaScreen, monitorIndex, metaWin) {
+    _windowEnteredMonitor(metaScreen, monitorIndex, metaWin) {
         let hide = metaWin.get_maximized();
         if (this._settings.get_boolean('only-main-monitor'))
             hide = monitorIndex == Main.layoutManager.primaryIndex;
         this._setHideTitlebar(metaWin, hide);
     }
 
-});
+}

--- a/metadata.json
+++ b/metadata.json
@@ -4,14 +4,7 @@
   "description": "No Title Bar removes the title bar from non-GTK applications and moves the window title and buttons to the top panel.\n\nTitlebars are also hidden for Wayland-native clients that don't use CSD. Some of the options may be incompatible with this. For issues on Wayland please visit github!\n\nThis is a fork of https://extensions.gnome.org/extension/1267/no-title-bar/ with added compatibility for Gnome 3.32.\n\nThis extension depends on some Xorg utilities. To install them:\n\n\u26ab Debian/Ubuntu: apt install x11-utils\n\u26ab Fedora/RHEL: dnf install xorg-x11-utils\n\u26ab Arch: pacman -S xorg-xprop",
   "url": "https://github.com/poehlerj/no-title-bar",
   "shell-version": [
-      "3.18",
-      "3.20",
-      "3.22",
-      "3.24",
-      "3.26",
-      "3.28",
-      "3.30",
-      "3.32"
+      "3.34"
   ],
   "version": 9
 }


### PR DESCRIPTION
This MR adapts no-title-bar to Gnome Shell 3.34, removing all the warnings and errors.