### PR TITLE
Fixed missing buttons when using only "Show buttons for snapped windows"

### DIFF
--- a/buttons.js
+++ b/buttons.js
@@ -346,7 +346,7 @@ var Buttons = class {
             visible = false;
             let win = Utils.getWindow();
             if (win) {
-                visible = win.decorated || this._settings.get_boolean('buttons-for-all-win');
+                visible = win._noTitleBarOriginalState || this._settings.get_boolean('buttons-for-all-win');
 
                 if (visible) {
                     visible = !Utils.isWindowIgnored(this._settings, win);

--- a/buttons.js
+++ b/buttons.js
@@ -346,8 +346,8 @@ var Buttons = class {
             visible = false;
             let win = Utils.getWindow();
             if (win) {
-                visible = win._noTitleBarOriginalState || this._settings.get_boolean('buttons-for-all-win');
-
+                visible = win._noTitleBarOriginalState == 'default' || this._settings.get_boolean('buttons-for-all-win');
+                
                 if (visible) {
                     visible = !Utils.isWindowIgnored(this._settings, win);
 

--- a/decoration.js
+++ b/decoration.js
@@ -423,7 +423,7 @@ var Decoration = class {
     }
 
     _getMotifHints(win) {
-        if (!win._NoTitleBarOriginalState) {
+        if (!win._noTitleBarOriginalState) {
             let state = this._getHintValue(win, '_NO_TITLE_BAR_ORIGINAL_STATE');
             if (!state) {
                 state = this._getHintValue(win, '_MOTIF_WM_HINTS');
@@ -431,10 +431,10 @@ var Decoration = class {
 
                 this._setHintValue(win, '_NO_TITLE_BAR_ORIGINAL_STATE', state.join(', '));
             }
-            win._NoTitleBarOriginalState = state;
+            win._noTitleBarOriginalState = state;
         }
 
-        return win._NoTitleBarOriginalState;
+        return win._noTitleBarOriginalState;
     }
 
     _handleWindow(win) {

--- a/decoration.js
+++ b/decoration.js
@@ -307,7 +307,7 @@ var Decoration = class {
 
         let xprops = GLib.spawn_command_line_sync(cmd);
         if (!xprops[0]) {
-            return win._noTitleBarOriginalState = State.UNKNOWN;
+            return win._noTitleBarOriginalState = WindowState.UNKNOWN;
         }
 
         let str = ByteArray.toString(xprops[1]);


### PR DESCRIPTION
This should fix issue #4 
in decoration.js _noTitleBarOriginalState was capitalized wrong and in buttons.js it was using decorated (which the extension overwrites)