### PR TITLE
Fix const window state in decorations

### DIFF
--- a/decoration.js
+++ b/decoration.js
@@ -11,7 +11,7 @@ const ByteArray = imports.byteArray;
 
 const ws_manager = global.workspace_manager;
 
-const WindowState = {
+var WindowState = {
     DEFAULT: 'default',
     HIDE_TITLEBAR: 'hide-titlebar',
     UNDECORATED: 'undecorated',


### PR DESCRIPTION
Gnome-shell shows this warning
```
Some code accessed the property 'WindowState' on the module 'decoration'. That property was defined with 'let' or 'const' inside the module. This was previously supported, but is not correct according to the ES6 standard. Any symbols to be exported from a module must be defined with 'var'. The property access will work as previously for the time being, but please fix your code anyway.
```