### PR TITLE
Remove Tweener import to make compatible with 3.38

### DIFF
--- a/app_menu.js
+++ b/app_menu.js
@@ -1,9 +1,9 @@
+const Clutter = imports.gi.Clutter;
 const Lang = imports.lang;
 const Main = imports.ui.main;
 const Mainloop = imports.mainloop;
 const Shell = imports.gi.Shell;
 const St = imports.gi.St;
-const Tweener = imports.ui.tweener;
 
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
@@ -199,11 +199,11 @@ var AppMenu = class {
                 this._tooltip.opacity = 0;
                 this._tooltip.set_position(x, y);
 
-                Tweener.removeTweens(this._tooltip);
-                Tweener.addTween(this._tooltip, {
+                this._tooltip.remove_all_transitions();
+                this._tooltip.ease({
                     opacity: 255,
                     time: SHOW_DURATION,
-                    transition: 'easeOutQuad',
+                    transition: Clutter.AnimationMode.EASE_OUT_QUAD,
                 });
 
                 return false;
@@ -212,11 +212,11 @@ var AppMenu = class {
             // If the event ran, then we hide.
             this._resetMenuCallback();
 
-            Tweener.removeTweens(this._tooltip);
-            Tweener.addTween(this._tooltip, {
+            this._tooltip.remove_all_transitions();
+            this._tooltip.ease({
                 opacity: 0,
                 time: HIDE_DURATION,
-                transition: 'easeOutQuad',
+                transition: Clutter.AnimationMode.EASE_OUT_QUAD,
                 onComplete: Lang.bind(this, function() {
                     if (this._tooltipIsShown) {
                         Main.uiGroup.remove_actor(this._tooltip);

--- a/buttons.js
+++ b/buttons.js
@@ -7,7 +7,6 @@ const Main = imports.ui.main;
 const Mainloop = imports.mainloop;
 const Meta = imports.gi.Meta;
 const St = imports.gi.St;
-const Tweener = imports.ui.tweener;
 
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
@@ -28,21 +27,19 @@ const Position = {
 
 // Functions for changing opacity (to act as auto-hiding)
 function b_hidden(box) {
-    Tweener.addTween(box,
-        {
-            opacity: 0,
-            time: 1 / 6,
-            transition: 'linear'
-        });
+    box.ease({
+        opacity: 0,
+        time: 1 / 6,
+        transition: Clutter.AnimationMode.LINEAR
+    });
 }
 
 function b_shown(box) {
-    Tweener.addTween(box,
-        {
-            opacity: 255,
-            time: 1 / 6,
-            transition: 'linear'
-        });
+    box.ease({
+        opacity: 255,
+        time: 1 / 6,
+        transition: Clutter.AnimationMode.LINEAR
+    });
 }
 
 /**

--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,7 @@
   "description": "No Title Bar removes the title bar from non-GTK applications and moves the window title and buttons to the top panel.\n\nTitlebars are also hidden for Wayland-native clients that don't use CSD. Some of the options may be incompatible with this. For issues on Wayland please visit github!\n\nThis is a fork of https://extensions.gnome.org/extension/1267/no-title-bar/ with added compatibility for Gnome 3.32.\n\nThis extension depends on some Xorg utilities. To install them:\n\n\u26ab Debian/Ubuntu: apt install x11-utils\n\u26ab Fedora/RHEL: dnf install xorg-x11-utils\n\u26ab Arch: pacman -S xorg-xprop",
   "url": "https://github.com/poehlerj/no-title-bar",
   "shell-version": [
-      "3.34", "3.36"
+      "3.34", "3.36", "3.38"
   ],
-  "version": 10
+  "version": 11
 }


### PR DESCRIPTION
This should be a more forward-looking fix than #23, provided I got the right replacement functions. So far it's working for me, although I'm not sure what I should be looking for to verify the changes don't break anything.